### PR TITLE
Add a semicolon to the CASE/ELSE insertion

### DIFF
--- a/logging_infra.sql
+++ b/logging_infra.sql
@@ -53,7 +53,7 @@ BEGIN
             UNNEST(
                 ARRAY(SELECT row_to_json(old_table)::jsonb FROM old_table),
                 ARRAY(SELECT row_to_json(new_table)::jsonb FROM new_table)
-            ) AS t(old_row, new_row)
+            ) AS t(old_row, new_row);
     END CASE;
     RETURN NULL;
 END;


### PR DESCRIPTION
I was getting errors trying to add this function, and I think it was from a missing semi-colon.

Adding one at the end of the INSERT fixed it.